### PR TITLE
Quick fix

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -72,7 +72,12 @@ function App() {
   const fetchAndInitialize = () => {
     getDailyScrmbl((fetchedWord) => {
         if (!word || fetchedWord !== word) {
+            // Reset to default values
             localStorage.clear();
+            setGameOver(false);
+            setHelpActive(true);
+            setElapsedSeconds(0);
+            setScrmblsLeft(3);
             setWord(fetchedWord);
             setGuess('_'.repeat(fetchedWord.length));
         } else if (!gameOver) {

--- a/src/App.js
+++ b/src/App.js
@@ -58,43 +58,30 @@ const ScrmblContainer = styled.div`
 `;
 
 function App() {
-  const [helpActive, setHelpActive] = React.useState(true);
-  const [word, setWord] = React.useState('');
+  const [word, setWord] = React.useState(localStorage.getItem('word') ?? '');
   const [scrmbled, setScrmbled] = React.useState('');
-  const [guess, setGuess] = React.useState('');
+  const [guess, setGuess] = React.useState(localStorage.getItem('guess') ?? '');
   const [correctIndexes, setCorrectIndexes] = React.useState([]);
-  const [scrmblsLeft, setScrmblsLeft] = React.useState(3);
+  const [scrmblsLeft, setScrmblsLeft] = React.useState(localStorage.getItem('scrmblsLeft') ?? 3);
   const [startTime, setStartTime] = React.useState(null);
-  const [elapsedSeconds, setElapsedSeconds] = React.useState(0);
-  const [gameOver, setGameOver] = React.useState(false);
+  const [elapsedSeconds, setElapsedSeconds] = React.useState(localStorage.getItem('elapsedSeconds') ?? 0);
+  const [gameOver, setGameOver] = React.useState(localStorage.getItem('gameOver') ?? false);
   const [wordShake, setWordShake] = React.useState(false);
+  const [helpActive, setHelpActive] = React.useState(gameOver ? false : true);
 
   const fetchAndInitialize = () => {
     getDailyScrmbl((fetchedWord) => {
-        const storedWord = localStorage.getItem('word');
-        const storedGameOver = localStorage.getItem('gameOver');
-        const storedElapsedSeconds = localStorage.getItem('elapsedSeconds');
-        const storedGuess = localStorage.getItem('guess');
-        const storedScrmblsLeft = localStorage.getItem('scrmblsLeft')
-
-        if (!storedWord || fetchedWord !== storedWord) {
+        if (!word || fetchedWord !== word) {
             localStorage.clear();
             setWord(fetchedWord);
             setGuess('_'.repeat(fetchedWord.length));
-        } else if (storedGameOver === "true") {
-            setGameOver(true);
-            setElapsedSeconds(Number(storedElapsedSeconds));
-            setWord(storedWord);
-            setGuess(storedGuess);
-            setScrmblsLeft(storedScrmblsLeft)
-        } else {
-            setWord(storedWord);
-            setGuess('_'.repeat(storedWord.length));
+        } else if (!gameOver) {
+            setGuess('_'.repeat(word.length));
         }
     });
   };
 
-  useEffect(fetchAndInitialize, []);
+  useEffect(fetchAndInitialize, [gameOver,word]);
 
   useEffect(() => {
     if (gameOver && guess === word) {
@@ -104,7 +91,7 @@ function App() {
         localStorage.setItem('guess', guess);
         localStorage.setItem('scrmblsLeft', scrmblsLeft)
     }
-  }, [gameOver, elapsedSeconds, word, guess]);
+  }, [gameOver, elapsedSeconds, word, guess, scrmblsLeft]);
 
   const startClock = () => {
     setStartTime(new Date());
@@ -204,7 +191,6 @@ function App() {
     setScrmblsLeft(prevScrmbls => prevScrmbls - 1); // Using function form to ensure correctness
   }, [word, scrmbled, scrmblsLeft, correctIndexes]);
 
-
   return (
     <Content>
       <AnimatePresence>
@@ -212,14 +198,13 @@ function App() {
           <Welcome
             close={() => setHelpActive(false)}
             startClock={startClock}
-            gameOver={gameOver}
           />
-        : gameOver &&
+        : gameOver ?
           <GameOver
             scrmblsLeft={scrmblsLeft}
             elapsedSeconds={elapsedSeconds}
             word={word}
-          />
+          /> : null
         }
       </AnimatePresence>
       <Header>

--- a/src/components/Welcome.jsx
+++ b/src/components/Welcome.jsx
@@ -47,8 +47,7 @@ const LetsPlayButton = styled.button`
   }
 `;
 
-const Welcome = ({ close, startClock, gameOver }) => {
-  if (gameOver) return;
+const Welcome = ({ close, startClock }) => {
   return (
     <Dialog>
       <Heading>How to play:</Heading>
@@ -66,6 +65,7 @@ const Welcome = ({ close, startClock, gameOver }) => {
         <ListItem>🎉 Crack the word, be the Scrmbl champ, and dance your way to a perfect score!</ListItem>
         
         <LetsPlayButton onClick={() => {
+          console.log("YOOOOO")
           close();
           startClock();
         }}>


### PR DESCRIPTION
I realized that the main problem with #32 is that `helpActive` isn't a saved value and always defaults to true. Now it's default value is dependent upon `gameOver`.

Additionally fixed an issue where the Welcome dialog would briefly show up before the Game Over screen due to previous states only being loaded after the new Scrmbl is downloaded.

__NOTE:__ When a new day arrives, the game over screen will probably (as it's stiil today, I haven't tested it yet) briefly show up for similar reasons. Maybe we should have the dialog blocker show up by default _then_ the respective dialog, or add a loading screen to make it more obvious what's happening (though we'd need to have a minimum time of a second or two), or even store the last time a new Scrmbl was retrieved and then only show the Game Over dialog if it's not time to reset.

__EXTRA NOTE:__ I know JS types can get a bit funky, but as I understand it, using `localStorage.getItem` for setting the default state value _should_ be fine... right? My statically typed language trained brain is telling me that just trusting JS to properly infer the type from the returned string is a bad idea, but I also know that it does it all the time, so I wanted to pass it by you to make sure it wouldn't create any obvious problems that you can see.